### PR TITLE
Add unit tests for org.gridkit.jvmtool.jackson.NumberOutput

### DIFF
--- a/sjk-json/src/tests/java/org/gridkit/jvmtool/jackson/NumberOutputTest.java
+++ b/sjk-json/src/tests/java/org/gridkit/jvmtool/jackson/NumberOutputTest.java
@@ -1,0 +1,67 @@
+package org.gridkit.jvmtool.jackson;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class NumberOutputTest {
+
+    @Test
+    public void testOutputIntCharArray() {
+        char[] c = new char[]
+                {'1', '2', '3', '4', '5', '6', '7', '8', '9', '0', '1'};
+
+        Assert.assertEquals(2, NumberOutput.outputInt(-1, c, 0));
+        Assert.assertEquals(2, NumberOutput.outputInt(15, c, 0));
+        Assert.assertEquals(4, NumberOutput.outputInt(2000, c, 0));
+        Assert.assertEquals(7, NumberOutput.outputInt(1000001, c, 0));
+        Assert.assertEquals(10, NumberOutput.outputInt(1000000001, c, 0));
+        Assert.assertEquals(10, NumberOutput.outputInt(2000000001, c, 0));
+        Assert.assertEquals(11, NumberOutput.outputInt(-2147483648, c, 0));
+    }
+
+    @Test
+    public void testOutputIntByteArray() {
+        byte[] bytes = new byte[]{1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 1};
+
+        Assert.assertEquals(2, NumberOutput.outputInt(-1, bytes, 0));
+        Assert.assertEquals(2, NumberOutput.outputInt(15, bytes, 0));
+        Assert.assertEquals(4, NumberOutput.outputInt(2000, bytes, 0));
+        Assert.assertEquals(7, NumberOutput.outputInt(1000001, bytes, 0));
+        Assert.assertEquals(10, NumberOutput.outputInt(1000000001, bytes, 0));
+        Assert.assertEquals(10, NumberOutput.outputInt(2000000001, bytes, 0));
+        Assert.assertEquals(11, NumberOutput.outputInt(-2147483648, bytes, 0));
+    }
+
+    @Test
+    public void testOutputLongCharArray() {
+        char[] c = new char[]
+                {'1', '2', '3', '4', '5', '6', '7', '8', '9', '0', '1'};
+
+        Assert.assertEquals(2, NumberOutput.outputLong(-1L, c, 0));
+        Assert.assertEquals(10, NumberOutput.outputLong(2147483647L, c, 0));
+        Assert.assertEquals(11, NumberOutput.outputLong(10000000001L, c, 0));
+        Assert.assertEquals(11, NumberOutput.outputLong(-2147483648L, c, 0));
+    }
+
+    @Test
+    public void testOutputLongByteArray() {
+        byte[] bytes = new byte[]{1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 1};
+
+        Assert.assertEquals(2, NumberOutput.outputLong(-1L, bytes, 0));
+        Assert.assertEquals(10, NumberOutput.outputLong(2147483647L, bytes, 0));
+        Assert.assertEquals(11, NumberOutput.outputLong(10000000001L, bytes, 0));
+        Assert.assertEquals(11, NumberOutput.outputLong(-2147483648L, bytes, 0));
+    }
+
+    @Test
+    public void testToString() {
+        Assert.assertEquals("3", NumberOutput.toString(3));
+        Assert.assertEquals("-1", NumberOutput.toString(-1));
+        Assert.assertEquals("20", NumberOutput.toString(20));
+        Assert.assertEquals("20", NumberOutput.toString(20L));
+        Assert.assertEquals("2.52", NumberOutput.toString(2.52));
+        Assert.assertEquals("2147483648", NumberOutput.toString(2147483648L));
+        Assert.assertEquals("-2147483649",
+                NumberOutput.toString(-2147483649L));
+    }
+}


### PR DESCRIPTION
I've analysed your codebase and noticed that `org.gridkit.jvmtool.jackson.NumberOutput` is not fully tested.
I've written some tests for the methods in this class with the help of [Diffblue Cover](https://www.diffblue.com/opensource).

Hopefully, these tests will help you detect any regressions caused by future code changes. If you would find it useful to have additional tests written for this repository, I would be more than happy to look at other classes that you consider important in a subsequent PR.